### PR TITLE
map epsilon to 'ε' instead of 'δ'

### DIFF
--- a/unicode-ls/src/main.rs
+++ b/unicode-ls/src/main.rs
@@ -180,7 +180,7 @@ async fn main() {
         "Gamma" => 'Γ',
         "delta" => 'δ',
         "Delta" => 'Δ',
-        "epsilon" => 'δ',
+        "epsilon" => 'ε',
         "zeta" => 'ζ',
         "eta" => 'η',
         "n" => 'η',


### PR DESCRIPTION
Currently epsilon is mapped to 'δ' which seems wrong. This PR maps it to 'ε' instead.